### PR TITLE
🐛 Visibility of OpenStreetMap::$dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ composer require jbelien/oauth2-OpenStreetMap
 $OpenStreetMapProvider = new \JBelien\OAuth2\Client\Provider\OpenStreetMap([
     'clientId'     => 'yourId',          // The client ID assigned to you by OpenStreetMap.org
     'clientSecret' => 'yourSecret',      // The client password assigned to you by OpenStreetMap.org
-    'redirectUri'  => 'yourRedirectUri'  // The return URL you specified for your app on OpenStreetMap.org
+    'redirectUri'  => 'yourRedirectUri', // The return URL you specified for your app on OpenStreetMap.org
+    'dev'          => false              // Whether to use the OpenStreetMap test environment at https://master.apis.dev.openstreetmap.org/
 ]);
 
 // Get authorization code

--- a/src/Provider/OpenStreetMap.php
+++ b/src/Provider/OpenStreetMap.php
@@ -12,7 +12,7 @@ class OpenStreetMap extends AbstractProvider
 {
     use BearerAuthorizationTrait;
 
-    private $dev = false;
+    protected $dev = false;
 
     public function __construct(array $options = [], array $collaborators = [])
     {


### PR DESCRIPTION
* Changes the visibility of OpenStreetMap::$dev to `protected` in order to avoid a PHP error when using league/oauth2-client v2.6.0
* Adds the 'dev' option to README.md

Fixes: #4 