### PR TITLE
options to change the default server urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ $OpenStreetMapProvider = new \JBelien\OAuth2\Client\Provider\OpenStreetMap([
     'clientSecret' => 'yourSecret',      // The client password assigned to you by OpenStreetMap.org
     'redirectUri'  => 'yourRedirectUri', // The return URL you specified for your app on OpenStreetMap.org
     'dev'          => false              // Whether to use the OpenStreetMap test environment at https://master.apis.dev.openstreetmap.org/
+    /*
+    For a particular need you can change the default server urls with this two options:
+    'osm_base_url' =>  'https://www.openstreetmap.org',
+    'osm_base_url_dev' => 'https://master.apis.dev.openstreetmap.org',
+    */
 ]);
 
 // Get authorization code
@@ -56,11 +61,11 @@ if (!isset($_GET['code'])) {
     } catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
         exit($e->getMessage());
     }
-        
+
     // Now you can store the results to session etc.
     $_SESSION['accessToken'] = $accessToken;
     $_SESSION['resourceOwner'] = $resourceOwner;
-    
+
     var_dump(
         $resourceOwner->getId(),
         $resourceOwner->getDisplayName(),

--- a/src/Provider/OpenStreetMap.php
+++ b/src/Provider/OpenStreetMap.php
@@ -13,13 +13,27 @@ class OpenStreetMap extends AbstractProvider
     use BearerAuthorizationTrait;
 
     protected $dev = false;
+    protected $base_url = 'https://www.openstreetmap.org' ;
+    protected $base_url_dev = 'https://master.apis.dev.openstreetmap.org' ;
 
+    /**
+     * Available options for OpenStreetMap provider:
+     * - dev : if True use "base_url_dev" otherwise "base_url".
+     * - osm_base_url : Url to use when "dev" is False.
+     * - osm_base_url_dev : Url to use when "dev" is True.
+     */
     public function __construct(array $options = [], array $collaborators = [])
     {
         parent::__construct($options, $collaborators);
 
         if (isset($options['dev'])) {
             $this->dev = (bool) $options['dev'];
+        }
+        if (isset($options['osm_base_url'])) {
+            $this->base_url = $options['osm_base_url'];
+        }
+        if (isset($options['osm_base_url_dev'])) {
+            $this->base_url_dev = $options['osm_base_url_dev'];
         }
     }
 
@@ -31,8 +45,8 @@ class OpenStreetMap extends AbstractProvider
     public function getBaseAuthorizationUrl()
     {
         return $this->dev ?
-            'https://master.apis.dev.openstreetmap.org/oauth2/authorize' :
-            'https://www.openstreetmap.org/oauth2/authorize';
+            $this->base_url_dev.'/oauth2/authorize' :
+            $this->base_url.'/oauth2/authorize';
     }
 
     /**
@@ -45,8 +59,8 @@ class OpenStreetMap extends AbstractProvider
     public function getBaseAccessTokenUrl(array $params)
     {
         return $this->dev ?
-            'https://master.apis.dev.openstreetmap.org/oauth2/token' :
-            'https://www.openstreetmap.org/oauth2/token';
+            $this->base_url_dev.'/oauth2/token' :
+            $this->base_url.'/oauth2/token';
     }
 
     /**
@@ -59,8 +73,8 @@ class OpenStreetMap extends AbstractProvider
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
         return $this->dev ?
-            'https://master.apis.dev.openstreetmap.org/api/0.6/user/details.json' :
-            'https://api.openstreetmap.org/api/0.6/user/details.json';
+            $this->base_url_dev.'/api/0.6/user/details.json' :
+            $this->base_url.'/api/0.6/user/details.json';
     }
 
     /**


### PR DESCRIPTION
Hi,

I just propose to permit the change of server urls, it's some times useful ;-)

The default behavior of the Provider does not change, just 2 new optional options.

The README talk about them : 

```php
$OpenStreetMapProvider = new \JBelien\OAuth2\Client\Provider\OpenStreetMap([
    'clientId'     => 'yourId',          // The client ID assigned to you by OpenStreetMap.org
    'clientSecret' => 'yourSecret',      // The client password assigned to you by OpenStreetMap.org
    'redirectUri'  => 'yourRedirectUri', // The return URL you specified for your app on OpenStreetMap.org
    'dev'          => false              // Whether to use the OpenStreetMap test environment at https://master.apis.dev.openstreetmap.org/
    /*
    For a particular need you can change the default server urls with this two options:
    'osm_base_url' =>  'https://www.openstreetmap.org',
    'osm_base_url_dev' => 'https://master.apis.dev.openstreetmap.org',
    */
]);
```

Thanks and cheers :-)
